### PR TITLE
ARObject Touch Support

### DIFF
--- a/Classes/AR/ARObject.h
+++ b/Classes/AR/ARObject.h
@@ -29,7 +29,7 @@
 
 #import "ARSettings.h"
 
-extern NSNotificationName ARObjectTappedNotification;
+extern NSNotificationName const ARObjectTappedNotification;
 
 @interface ARObject : UIViewController
 {

--- a/Classes/AR/ARObject.h
+++ b/Classes/AR/ARObject.h
@@ -29,6 +29,7 @@
 
 #import "ARSettings.h"
 
+extern NSNotificationName ARObjectTappedNotification;
 
 @interface ARObject : UIViewController
 {

--- a/Classes/AR/ARObject.m
+++ b/Classes/AR/ARObject.m
@@ -26,6 +26,7 @@
 
 #import "ARObject.h"
 
+NSNotificationName const ARObjectTappedNotification = @"kARObjectTappedNotification";
 
 @interface ARObject ()
 
@@ -96,6 +97,12 @@ andCurrentLocation:(CLLocationCoordinate2D)currLoc
     [distanceL setText:[self getDistanceLabelText]];
 }
 
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"kARObjectTappedNotification" object:self];
+}
 
 #pragma mark -- OO Methods
 

--- a/Classes/AR/ARObject.m
+++ b/Classes/AR/ARObject.m
@@ -101,7 +101,7 @@ andCurrentLocation:(CLLocationCoordinate2D)currLoc
 {
     [super touchesBegan:touches withEvent:event];
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"kARObjectTappedNotification" object:self];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ARObjectTappedNotification object:self];
 }
 
 #pragma mark -- OO Methods


### PR DESCRIPTION
A NSNotification is posted when an ARObject is tapped. The current ARObject is passed as an object through the NSNotificationCenter