### PR TITLE
Don't crash the sample app when running on new devices (#57)

### DIFF
--- a/PRAR-Simple/PRAR-Simple/PRAR-Simple-Info.plist
+++ b/PRAR-Simple/PRAR-Simple/PRAR-Simple-Info.plist
@@ -36,5 +36,7 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>The app displays annotation in the world around, overlaying the video from your camera.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Before accessing the camera an app needs to ask for permission,
otherwise it crashes, rendering it unusable and stalling the device
when debugging.