### PR TITLE
Add support for Cocoapods 1.2.0 to PRAR-Example app (#59)

### DIFF
--- a/PRAR-Example/PRAR-Example.xcodeproj/project.pbxproj
+++ b/PRAR-Example/PRAR-Example.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		003A934603118B11898B2BFD /* libPods-PRAR-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80DDEEA341EC1F4A54CEF2FB /* libPods-PRAR-Example.a */; };
 		3617F1D9179A575900483A8D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3617F1D8179A575900483A8D /* SystemConfiguration.framework */; };
 		36281F941811BBAA00860A3D /* NE.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 36281F901811BBAA00860A3D /* NE.gpx */; };
 		36281F951811BBAA00860A3D /* NW.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 36281F911811BBAA00860A3D /* NW.gpx */; };
@@ -59,10 +60,10 @@
 		36CF8C2B179A5122007BE243 /* MyLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 36CF8C1F179A5122007BE243 /* MyLocation.m */; };
 		36CF8C2C179A5122007BE243 /* TestLoc.gpx in Resources */ = {isa = PBXBuildFile; fileRef = 36CF8C20179A5122007BE243 /* TestLoc.gpx */; };
 		36CF8C2D179A5122007BE243 /* ARView.m in Sources */ = {isa = PBXBuildFile; fileRef = 36CF8C23179A5122007BE243 /* ARView.m */; };
-		F61B17E40E8045EDBCC3C456 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E563340322446E1BA5E6309 /* libPods.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0906D032B9E13221AE3ECF71 /* Pods-PRAR-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PRAR-Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PRAR-Example/Pods-PRAR-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		3617F1D8179A575900483A8D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		36281F901811BBAA00860A3D /* NE.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NE.gpx; sourceTree = "<group>"; };
 		36281F911811BBAA00860A3D /* NW.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = NW.gpx; sourceTree = "<group>"; };
@@ -136,8 +137,9 @@
 		36CF8C20179A5122007BE243 /* TestLoc.gpx */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = TestLoc.gpx; sourceTree = "<group>"; };
 		36CF8C22179A5122007BE243 /* ARView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARView.h; path = "Main Views/ARView.h"; sourceTree = "<group>"; };
 		36CF8C23179A5122007BE243 /* ARView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARView.m; path = "Main Views/ARView.m"; sourceTree = "<group>"; };
-		762233081DD540489E511D03 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
 		7E563340322446E1BA5E6309 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		80DDEEA341EC1F4A54CEF2FB /* libPods-PRAR-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PRAR-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BDB705311426CDA9D4B65ADB /* Pods-PRAR-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PRAR-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-PRAR-Example/Pods-PRAR-Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -155,7 +157,7 @@
 				36CF8BDC179A5088007BE243 /* UIKit.framework in Frameworks */,
 				36CF8BDE179A5088007BE243 /* Foundation.framework in Frameworks */,
 				36CF8BE0179A5088007BE243 /* CoreGraphics.framework in Frameworks */,
-				F61B17E40E8045EDBCC3C456 /* libPods.a in Frameworks */,
+				003A934603118B11898B2BFD /* libPods-PRAR-Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -246,7 +248,7 @@
 				36CF8BE1179A5088007BE243 /* PRAR-Example */,
 				36CF8BDA179A5088007BE243 /* Frameworks */,
 				36CF8BD9179A5088007BE243 /* Products */,
-				762233081DD540489E511D03 /* Pods.xcconfig */,
+				976A74408A179319312124DB /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -266,6 +268,7 @@
 				36CF8BDD179A5088007BE243 /* Foundation.framework */,
 				36CF8BDF179A5088007BE243 /* CoreGraphics.framework */,
 				7E563340322446E1BA5E6309 /* libPods.a */,
+				80DDEEA341EC1F4A54CEF2FB /* libPods-PRAR-Example.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -350,6 +353,15 @@
 			path = DIOS;
 			sourceTree = "<group>";
 		};
+		976A74408A179319312124DB /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0906D032B9E13221AE3ECF71 /* Pods-PRAR-Example.debug.xcconfig */,
+				BDB705311426CDA9D4B65ADB /* Pods-PRAR-Example.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -357,11 +369,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 36CF8BFB179A5088007BE243 /* Build configuration list for PBXNativeTarget "PRAR-Example" */;
 			buildPhases = (
-				AEA5051E3AA24213AAE42689 /* Check Pods Manifest.lock */,
+				AEA5051E3AA24213AAE42689 /* [CP] Check Pods Manifest.lock */,
 				36CF8BD4179A5088007BE243 /* Sources */,
 				36CF8BD5179A5088007BE243 /* Frameworks */,
 				36CF8BD6179A5088007BE243 /* Resources */,
-				2A720F675B084A2F9CF727A1 /* Copy Pods Resources */,
+				2A720F675B084A2F9CF727A1 /* [CP] Copy Pods Resources */,
+				0A6E6F0ABDD6A58D180B97C2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -434,33 +447,48 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2A720F675B084A2F9CF727A1 /* Copy Pods Resources */ = {
+		0A6E6F0ABDD6A58D180B97C2 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PRAR-Example/Pods-PRAR-Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
-		AEA5051E3AA24213AAE42689 /* Check Pods Manifest.lock */ = {
+		2A720F675B084A2F9CF727A1 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PRAR-Example/Pods-PRAR-Example-resources.sh\"\n";
+		};
+		AEA5051E3AA24213AAE42689 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -569,30 +597,38 @@
 		};
 		36CF8BFC179A5088007BE243 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 762233081DD540489E511D03 /* Pods.xcconfig */;
+			baseConfigurationReference = 0906D032B9E13221AE3ECF71 /* Pods-PRAR-Example.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PRAR-Example/PRAR-Example-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "PRAR-Example/PRAR-Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "2D3ECB70-0561-4B27-8563-0AC2AE89E303";
+				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
 		36CF8BFD179A5088007BE243 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 762233081DD540489E511D03 /* Pods.xcconfig */;
+			baseConfigurationReference = BDB705311426CDA9D4B65ADB /* Pods-PRAR-Example.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "PRAR-Example/PRAR-Example-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "PRAR-Example/PRAR-Example-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "2D3ECB70-0561-4B27-8563-0AC2AE89E303";
+				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/PRAR-Example/PRAR-Example/PRAR-Example-Info.plist
+++ b/PRAR-Example/PRAR-Example/PRAR-Example-Info.plist
@@ -20,7 +20,7 @@
 		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.prometsource.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/PRAR-Example/podfile
+++ b/PRAR-Example/podfile
@@ -1,5 +1,10 @@
 platform :ios, '6.0'
 
-pod 'FMDB', '~> 2.0'
-pod 'AFNetworking', '~> 1.0'
-pod 'SCNetworkReachability', '~> 1.0'
+target 'PRAR-Example' do
+
+  # Pods for PRAR-Example
+  pod 'FMDB', '~> 2.0'
+  pod 'AFNetworking', '~> 1.0'
+  pod 'SCNetworkReachability', '~> 1.0'
+
+end


### PR DESCRIPTION
Running `pod install` with Cocoapods 1.2.0 should not result in errors.